### PR TITLE
add babel transform for Object.assign, fixes #4

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,6 @@
   "presets": [
     "es2015",
     "stage-0"
-  ]
+  ],
+  "plugins": ["transform-object-assign"]
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-core": "^6.7.7",
     "babel-eslint": "^6.1.1",
     "babel-loader": "^6.2.4",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.7.2",


### PR DESCRIPTION
IMHO it's best to just add a simple transform for the Object.assign method, due to the super small scope of the library.

#4 